### PR TITLE
Fixes and upgrades for SAP NW 7.52 version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /work/
 /target/
+/bin/

--- a/src/main/java/com/mycompany/abapci/AbapCiBuilder.java
+++ b/src/main/java/com/mycompany/abapci/AbapCiBuilder.java
@@ -1,5 +1,20 @@
 package com.mycompany.abapci;
 
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.MalformedURLException;
+
+import javax.servlet.ServletException;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.util.EntityUtils;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
 import com.mycompany.abapci.AdtCommunication.AtcHttpPostHandler;
 import com.mycompany.abapci.AdtCommunication.IHttpPostHandler;
 import com.mycompany.abapci.AdtCommunication.SapConnectionInfo;
@@ -7,189 +22,225 @@ import com.mycompany.abapci.AdtCommunication.SapCredentials;
 import com.mycompany.abapci.AdtCommunication.SapServerInfo;
 import com.mycompany.abapci.AdtCommunication.UnittestHttpPostHandler;
 import com.mycompany.resultParser.AtcCheckResultParser;
+import com.mycompany.resultParser.UnitTestResult;
 import com.mycompany.resultParser.UnittestResultParser;
+
 import hudson.AbortException;
-import hudson.Launcher;
 import hudson.Extension;
 import hudson.FilePath;
-import hudson.util.FormValidation;
+import hudson.Launcher;
 import hudson.model.AbstractProject;
 import hudson.model.Run;
 import hudson.model.TaskListener;
-import hudson.tasks.Builder;
 import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
+import hudson.util.FormValidation;
 import hudson.util.Secret;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
-
-import javax.servlet.ServletException;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.net.MalformedURLException;
 import jenkins.tasks.SimpleBuildStep;
-import org.apache.commons.lang.StringUtils;
-import org.apache.http.HttpResponse;
-import org.apache.http.util.EntityUtils;
-import org.jenkinsci.Symbol;
-import org.kohsuke.stapler.DataBoundSetter;
 
 public class AbapCiBuilder extends Builder implements SimpleBuildStep {
 
-    private String abapPackagename;
-    private boolean useJenkinsProjectname;
-    private boolean runUnitTests;
-    private boolean runAtcChecks;
+	private String abapPackagename;
+	private boolean useJenkinsProjectname;
+	private boolean runUnitTests;
+	private boolean runAtcChecks;
+	private String atcVariant;
+	private boolean treatWarningAtcChecksAsErrors;
 
-    @DataBoundConstructor
-    public AbapCiBuilder(String abapPackagename) {
-        this.abapPackagename = abapPackagename;
-    }
+	@DataBoundConstructor
+	public AbapCiBuilder(String abapPackagename, String atcVariant) {
+		this.abapPackagename = abapPackagename;
+		
+		if(atcVariant == null || atcVariant.length() == 0) {
+			this.atcVariant = "DEFAULT";
+		} else {
+			this.atcVariant = atcVariant;
+		}
+	}
 
-    public String getAbapPackagename() {
-        return abapPackagename;
-    }
+	public String getAbapPackagename() {
+		return abapPackagename;
+	}
 
-    @DataBoundSetter
-    public void setAbapPackagename(String sapPackagename) {
-        this.abapPackagename = sapPackagename;
-    }
+	@DataBoundSetter
+	public void setAbapPackagename(String sapPackagename) {
+		this.abapPackagename = sapPackagename;
+	}
 
-    public boolean getUseJenkinsProjectName() {
-        return useJenkinsProjectname;
-    }
+	public boolean getUseJenkinsProjectName() {
+		return useJenkinsProjectname;
+	}
 
-    @DataBoundSetter
-    public void setuseJenkinsProjectName(boolean useJenkinsProjectname) {
-        this.useJenkinsProjectname = useJenkinsProjectname;
-    }
-    
-    public boolean isRunUnitTests() {
-        return runUnitTests;
-    }
+	@DataBoundSetter
+	public void setuseJenkinsProjectName(boolean useJenkinsProjectname) {
+		this.useJenkinsProjectname = useJenkinsProjectname;
+	}
 
-    @DataBoundSetter
-    public void setRunUnitTests(boolean runUnitTests) {
-        this.runUnitTests = runUnitTests;
-    }
+	public boolean isRunUnitTests() {
+		return runUnitTests;
+	}
 
-    public boolean isRunAtcChecks() {
-        return runAtcChecks;
-    }
+	@DataBoundSetter
+	public void setRunUnitTests(boolean runUnitTests) {
+		this.runUnitTests = runUnitTests;
+	}
 
-    @DataBoundSetter
-    public void setRunAtcChecks(boolean runAtcChecks) {
-        this.runAtcChecks = runAtcChecks;
-    }
+	public boolean isRunAtcChecks() {
+		return runAtcChecks;
+	}
 
+	@DataBoundSetter
+	public void setRunAtcChecks(boolean runAtcChecks) {
+		this.runAtcChecks = runAtcChecks;
+	}
 
-    @Override
-    public void perform(Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener listener)
-            throws InterruptedException, IOException, MalformedURLException {
+	public String getAtcVariant() {
+		return this.atcVariant;
+	}
 
-        int numFailedUnittests = -1;
-        int numCriticalAtcChecks = -1;
+	@DataBoundSetter
+	public void setAtcVariant(String variant) {
+		this.atcVariant = variant;
+	}
+	
+	public boolean getTreatWarningAtcChecksAsErrors() {
+		return treatWarningAtcChecksAsErrors;
+	}
+	
+	@DataBoundSetter
+	public void setTreatWarningAtcChecksAsErrors(boolean treatWarningAtcChecksAsErrors) {
+		this.treatWarningAtcChecksAsErrors = treatWarningAtcChecksAsErrors;
+	}
 
-        AbapCiGlobalConfiguration globalConfiguration = AbapCiGlobalConfiguration.get();
-        boolean globalConfigurationIsValid = ValidateGlobalConfiguration(globalConfiguration);
-        if (globalConfigurationIsValid) {
+	@Override
+	public void perform(Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener listener)
+			throws InterruptedException, IOException, MalformedURLException {
 
-            listener.getLogger().println("Use jenkins project name as package name: " + useJenkinsProjectname + "!");
+		int numFailedUnitTests = -1;
+		int numCriticalAtcChecks = -1;
 
-            String username = globalConfiguration.getSapUsername();
-            Secret password = globalConfiguration.getSapPassword();
-            SapCredentials sapCredentials = new SapCredentials(username, password);
-            SapServerInfo sapServerInfo = new SapServerInfo(
-                    globalConfiguration.getSapProtocol(),
-                    globalConfiguration.getSapServername(),
-                    globalConfiguration.getSapPort(),
-                    globalConfiguration.getSapMandant());
-            SapConnectionInfo sapConnectionInfo = new SapConnectionInfo(sapServerInfo, sapCredentials);
+		AbapCiGlobalConfiguration globalConfiguration = AbapCiGlobalConfiguration.get();
+		boolean globalConfigurationIsValid = ValidateGlobalConfiguration(globalConfiguration);
 
-            try {
-                
-                listener.getLogger().println("Run Unit Test flag is: " + isRunUnitTests());
-                if (isRunUnitTests()) {
-                    listener.getLogger().println("Start ABAP Unit testrun for SAP packagename: " + abapPackagename + "!");
+		if (globalConfigurationIsValid) {
+			listener.getLogger().println("Use jenkins project name as package name: " + useJenkinsProjectname + "!");
 
-                    IHttpPostHandler httpPostHandler = new UnittestHttpPostHandler(sapConnectionInfo, abapPackagename, listener);
-                    HttpResponse response = httpPostHandler.executeWithToken();
-                    listener.getLogger().println("Response statuscode of unit testrun: " + response.getStatusLine().getStatusCode());
+			String username = globalConfiguration.getSapUsername();
+			Secret password = globalConfiguration.getSapPassword();
+			SapCredentials sapCredentials = new SapCredentials(username, password);
+			SapServerInfo sapServerInfo = new SapServerInfo(globalConfiguration.getSapProtocol(),
+					globalConfiguration.getSapServername(), globalConfiguration.getSapPort(),
+					globalConfiguration.getSapMandant());
+			SapConnectionInfo sapConnectionInfo = new SapConnectionInfo(sapServerInfo, sapCredentials);
 
-                    if (response.getStatusLine().getStatusCode() == 200) {
-                        String responseContent = EntityUtils.toString(response.getEntity(), "UTF-8");
-                        listener.getLogger().println("Response content of unit testrun: " + responseContent);
-                        UnittestResultParser jsonParser = new UnittestResultParser();
-                        numFailedUnittests = jsonParser.parseXmlForFailedElements(responseContent);
-                        listener.getLogger().println("Number of failed unittests: " + numFailedUnittests);
+			try {
+				listener.getLogger().println("Run Unit Test flag is: " + isRunUnitTests());
 
-                    }
-                }
+				if (isRunUnitTests()) {
+					listener.getLogger()
+							.println("########## Start ABAP Unit testrun for SAP packagename: " + abapPackagename + "! ##########");
 
-                listener.getLogger().println("Run ATC checks flag is: " + isRunAtcChecks());
-                if (isRunAtcChecks()) {
-                    listener.getLogger().println("Start ATC checkrun for SAP packagename: " + abapPackagename + "!");
+					IHttpPostHandler httpPostHandler = new UnittestHttpPostHandler(sapConnectionInfo, abapPackagename,
+							listener);
+					HttpResponse response = httpPostHandler.executeWithToken();
+					listener.getLogger().println(
+							"Response statuscode of unit testrun: " + response.getStatusLine().getStatusCode());
 
-                    IHttpPostHandler httpPostHandlerAtc = new AtcHttpPostHandler(sapConnectionInfo, abapPackagename, listener);
-                    HttpResponse atcResponse = httpPostHandlerAtc.executeWithToken();
-                    listener.getLogger().println("Response statuscode of atc run: " + atcResponse.getStatusLine().getStatusCode());
+					if (response.getStatusLine().getStatusCode() == 200) {
+						String responseContent = EntityUtils.toString(response.getEntity(), "UTF-8");
+						// listener.getLogger().println("Response content of unit testrun: " +
+						// responseContent);
+						UnittestResultParser jsonParser = new UnittestResultParser();
+						UnitTestResult unitTestResult = jsonParser.parseXmlForFailedElements(responseContent);
 
-                    if (atcResponse.getStatusLine().getStatusCode() == 200) {
-                        String responseContent = EntityUtils.toString(atcResponse.getEntity(), "UTF-8");
-                        listener.getLogger().println("Response content of ÁTC checks: " + responseContent);
-                        AtcCheckResultParser jsonParser = new AtcCheckResultParser();
-                        numCriticalAtcChecks = jsonParser.parseXmlForFailedElements(responseContent);
-                        listener.getLogger().println("Number of failed ATC checks: " + numCriticalAtcChecks);
-                    }
-                }
-            } catch (RuntimeException rex) {
-                throw rex;  
-            } catch (Exception e) {
-                StringWriter sw = new StringWriter();
-                e.printStackTrace(new PrintWriter(sw));
-                listener.getLogger().println("Http Call failed, exception message: " + e.getMessage());
-                listener.getLogger().println("Http Call failed, exception stacktrace: " + sw.toString());
-                throw new InterruptedException();
-            }
-            if (numFailedUnittests > 0) {
-                throw new AbortException("Failed Unit tests");
-            }
-            if (numCriticalAtcChecks > 0) {
-                throw new AbortException("Failed ATC checks");
-            }
+						if (unitTestResult.getMessages().size() > 0) {
+							listener.getLogger().println("---------------------------");
+						}
 
-        }
-    }
+						unitTestResult.getMessages().forEach(item -> {
+							String message = (String) item;
+							listener.getLogger().println(message);
+						});
 
-    private boolean ValidateGlobalConfiguration(AbapCiGlobalConfiguration globalConfiguration) {
-        boolean servernameIsSet = !StringUtils.isEmpty(globalConfiguration.getSapServername());
-        //TODO 
-        return servernameIsSet;
-    }
+						numFailedUnitTests = unitTestResult.getNumOfFailedTests();
 
-    @Symbol("abapCi")
-    @Extension
-    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
+						listener.getLogger().println("Number of failed unittests: " + numFailedUnitTests);
 
-        public FormValidation doCheckName(@QueryParameter String value)
-                throws IOException, ServletException {
-            if (value.length() == 0) {
-                return FormValidation.error("Please set a package name");
-            }
+					}
+				}
 
-            return FormValidation.ok();
-        }
+				listener.getLogger().println("Run ATC checks flag is: " + isRunAtcChecks());
 
-        @Override
-        public boolean isApplicable(Class<? extends AbstractProject> aClass) {
-            return true;
-        }
+				if (isRunAtcChecks()) {
+					listener.getLogger().println("########## Start ATC checkrun for SAP packagename: " + abapPackagename + "! ##########");
 
-        @Override
-        public String getDisplayName() {
-            return "ABAP Continuous Integration Plugin";
-        }
+					IHttpPostHandler httpPostHandlerAtc = new AtcHttpPostHandler(sapConnectionInfo, abapPackagename,
+							listener, this.atcVariant);
+					HttpResponse atcResponse = httpPostHandlerAtc.executeWithToken();
+					listener.getLogger()
+							.println("Response statuscode of atc run: " + atcResponse.getStatusLine().getStatusCode());
 
-    }
+					if (atcResponse.getStatusLine().getStatusCode() == 200) {
+						String responseContent = EntityUtils.toString(atcResponse.getEntity(), "UTF-8");
+						//listener.getLogger().println("Response content of Ã�TC checks: " + responseContent);
+						AtcCheckResultParser jsonParser = new AtcCheckResultParser(this.treatWarningAtcChecksAsErrors);
+						numCriticalAtcChecks = jsonParser.parseXmlForFailedElements(responseContent);
+						listener.getLogger().println("Number of failed ATC checks: " + numCriticalAtcChecks);
+					}
+				}
+			} catch (RuntimeException rex) {
+				throw rex;
+			} catch (Exception e) {
+				StringWriter sw = new StringWriter();
+				e.printStackTrace(new PrintWriter(sw));
+				listener.getLogger().println("Http Call failed, exception message: " + e.getMessage());
+				listener.getLogger().println("Http Call failed, exception stacktrace: " + sw.toString());
+				throw new InterruptedException();
+			}
+
+			if (numFailedUnitTests > 0 && numCriticalAtcChecks > 0) {
+				throw new AbortException("Failed unit tests and ATC checks");
+			}
+
+			if (numFailedUnitTests > 0) {
+				throw new AbortException("Failed unit tests");
+			}
+
+			if (numCriticalAtcChecks > 0) {
+				throw new AbortException("Failed ATC checks");
+			}
+
+		}
+	}
+
+	private boolean ValidateGlobalConfiguration(AbapCiGlobalConfiguration globalConfiguration) {
+		boolean servernameIsSet = !StringUtils.isEmpty(globalConfiguration.getSapServername());
+		// TODO
+		return servernameIsSet;
+	}
+
+	@Symbol("abapCi")
+	@Extension
+	public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
+
+		public FormValidation doCheckName(@QueryParameter String value) throws IOException, ServletException {
+			if (value.length() == 0) {
+				return FormValidation.error("Please set a package name");
+			}
+
+			return FormValidation.ok();
+		}
+
+		@Override
+		public boolean isApplicable(Class<? extends AbstractProject> aClass) {
+			return true;
+		}
+
+		@Override
+		public String getDisplayName() {
+			return "ABAP Continuous Integration Plugin";
+		}
+
+	}
 
 }

--- a/src/main/java/com/mycompany/abapci/AdtCommunication/AtcHttpPostHandler.java
+++ b/src/main/java/com/mycompany/abapci/AdtCommunication/AtcHttpPostHandler.java
@@ -23,11 +23,9 @@
  */
 package com.mycompany.abapci.AdtCommunication;
 
-import hudson.model.TaskListener;
-import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
-import org.apache.commons.io.FileUtils;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
@@ -35,80 +33,82 @@ import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.util.EntityUtils;
 
+import hudson.model.TaskListener;
+
 /**
  *
  * @author Andreas Gautsch
  */
 public class AtcHttpPostHandler extends AHttpPostHandler {
+	private String atcVariant;
 
-    public AtcHttpPostHandler(SapConnectionInfo sapConnectionInfo, String sapPackageName, TaskListener listener) {
-        super(sapConnectionInfo, sapPackageName, listener);
-    }
+	public AtcHttpPostHandler(SapConnectionInfo sapConnectionInfo, String sapPackageName, TaskListener listener,
+			String atcVariant) {
+		super(sapConnectionInfo, sapPackageName, listener);
+		this.atcVariant = atcVariant;
+	}
 
-    @Override
-    protected HttpResponse postRequest(AdtInitialConnectionReponseHeaders adtInitialConnectionResponseHeaders) throws MalformedURLException, IOException {
-        HttpClient httpclientCheckVariant = new DefaultHttpClient();
+	@Override
+	protected HttpResponse postRequest(AdtInitialConnectionReponseHeaders adtInitialConnectionResponseHeaders)
+			throws MalformedURLException, IOException {
+		HttpClient httpclientCheckVariant = new DefaultHttpClient();
 
-        String url = BuildHttpUrl(GetMainUrlTarget());
-        HttpPost httppost = new HttpPost(url);
-        AddHeaderForHttpPostRequest(httppost, adtInitialConnectionResponseHeaders);
+		String url = BuildHttpUrl(GetMainUrlTarget());
+		HttpPost httppost = new HttpPost(url);
+		AddHeaderForHttpPostRequest(httppost, adtInitialConnectionResponseHeaders);
 
-        HttpResponse checkVariantResponse = httpclientCheckVariant.execute(httppost);
-        String worklistId = EntityUtils.toString(checkVariantResponse.getEntity(), "UTF-8");
+		HttpResponse checkVariantResponse = httpclientCheckVariant.execute(httppost);
+		String worklistId = EntityUtils.toString(checkVariantResponse.getEntity(), "UTF-8");
 
-        HttpClient httpclientAtcRun = new DefaultHttpClient();
+		HttpClient httpclientAtcRun = new DefaultHttpClient();
 
-        String urlAtcRunResult = BuildHttpUrl(GetAtcRunResultUrlTarget(worklistId));
-        HttpPost httppostAtcRun = new HttpPost(urlAtcRunResult);
-        AddHeaderForHttpPostRequest(httppostAtcRun, adtInitialConnectionResponseHeaders);
+		String urlAtcRunResult = BuildHttpUrl(GetAtcRunResultUrlTarget(worklistId));
+		HttpPost httppostAtcRun = new HttpPost(urlAtcRunResult);
+		AddHeaderForHttpPostRequest(httppostAtcRun, adtInitialConnectionResponseHeaders);
 
-        String postMessageAtcRunResult = GetPostMessage();
+		String postMessageAtcRunResult = GetPostMessage();
+		httppostAtcRun.setEntity(new ByteArrayEntity(postMessageAtcRunResult.getBytes("UTF8")));
 
-        httppostAtcRun.setEntity(new ByteArrayEntity(
-                postMessageAtcRunResult.getBytes("UTF8")));
+		return httpclientAtcRun.execute(httppostAtcRun);
 
-        return httpclientAtcRun.execute(httppostAtcRun);
+	}
 
-    }
+	@Override
+	String GetMainUrlTarget() {
+		return "/sap/bc/adt/atc/worklists?checkVariant=" + this.atcVariant;
+	}
 
-    @Override
-    String GetMainUrlTarget() {
-        return "/sap/bc/adt/atc/worklists?checkVariant=DEFAULT";
-    }
+	@Override
+	String GetTokenUrlTarget() {
+		return "/sap/bc/adt/atc/worklists";
+	}
 
-    @Override
-    String GetTokenUrlTarget() {
-        return "/sap/bc/adt/atc/worklists";
-    }
+	String GetAtcRunResultUrlTarget(String worklistId) {
+		return "/sap/bc/adt/atc/runs?worklistId=" + worklistId;
+	}
 
-    String GetAtcRunResultUrlTarget(String worklistId) {
-        return "/sap/bc/adt/atc/runs?worklistId=" + worklistId;
-    }
+	@Override
+	String GetPostMessage() throws IOException {
+		String postMessage = GetRequestMessageXml();
+		postMessage = postMessage.replace("{sapPackageName}", _sapPackageName);
 
-    @Override
-    String GetPostMessage() throws IOException {
-        String postMessage = GetRequestMessageXml();
-        postMessage = postMessage.replace("{sapPackageName}", _sapPackageName);
+		return postMessage;
+	}
 
-        return postMessage;
-    }
+	private String GetRequestMessageXml() {
+		// TODO load content from file, this does not work with the maven released hpi
+		// package
+		// File file = new
+		// File(AtcHttpPostHandler.class.getClassLoader().getResource("atcRequestMessage.xml").getFile());
+		// String postMessage = FileUtils.readFileToString(file, "utf-8");
 
-    private String GetRequestMessageXml() {
-        //TODO load content from file, this does not work with the maven released hpi package 
-        //File file = new File(AtcHttpPostHandler.class.getClassLoader().getResource("atcRequestMessage.xml").getFile());
-        //String postMessage = FileUtils.readFileToString(file, "utf-8");
+		return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+				+ "<atc:run xmlns:atc=\"http://www.sap.com/adt/atc\" maximumVerdicts=\"100\">"
+				+ "<objectSets xmlns:adtcore=\"http://www.sap.com/adt/core\">" + "<objectSet kind=\"inclusive\">"
+				+ "<adtcore:objectReferences>"
+				+ "<adtcore:objectReference adtcore:uri=\"/sap/bc/adt/vit/wb/object_type/devck/object_name/{sapPackageName}\"/>"
+				+ "</adtcore:objectReferences>" + "</objectSet>" + "</objectSets>" + "</atc:run>";
 
-        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-                + "<atc:run xmlns:atc=\"http://www.sap.com/adt/atc\" maximumVerdicts=\"100\">"
-                + "<objectSets xmlns:adtcore=\"http://www.sap.com/adt/core\">"
-                + "<objectSet kind=\"inclusive\">"
-                + "<adtcore:objectReferences>"
-                + "<adtcore:objectReference adtcore:uri=\"/sap/bc/adt/vit/wb/object_type/devck/object_name/{sapPackageName}\"/>"
-                + "</adtcore:objectReferences>"
-                + "</objectSet>"
-                + "</objectSets>"
-                + "</atc:run>";
-
-    }
+	}
 
 }

--- a/src/main/java/com/mycompany/resultParser/UnitTestResult.java
+++ b/src/main/java/com/mycompany/resultParser/UnitTestResult.java
@@ -1,0 +1,30 @@
+package com.mycompany.resultParser;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class UnitTestResult {
+	private int numOfFailedTests;
+	private List<String> messages = new ArrayList<String>();
+	
+	public void setNumOfFailedTests(int numOfFailedTests) {
+		this.numOfFailedTests = numOfFailedTests;
+	}
+
+	public void appendMessage(String message) {
+		messages.add(message);
+	}
+	
+	public void appendMessages(Collection<String> messages) {
+		this.messages.addAll(messages);
+	}
+
+	public int getNumOfFailedTests() {
+		return numOfFailedTests;
+	}
+
+	public List<String> getMessages() {
+		return messages;
+	}
+}

--- a/src/main/resources/com/mycompany/abapci/AbapCiBuilder/config.jelly
+++ b/src/main/resources/com/mycompany/abapci/AbapCiBuilder/config.jelly
@@ -8,9 +8,14 @@
     <f:entry title="${%Run Unit tests}" field="runUnitTests" checked="true">
         <f:checkbox/>
     </f:entry>
-
     <f:entry title="${%Run ATC checks}" field="runAtcChecks">
         <f:checkbox />
+    </f:entry>
+    <f:entry title="${%ATC variant}" field="atcVariant">
+    	<f:textbox />
+    </f:entry>
+    <f:entry title="${%Treat ATC warnings as failures}" field="treatWarningAtcChecksAsErrors" checked="true">
+    	 <f:checkbox />
     </f:entry>
 
     <f:advanced>

--- a/src/test/java/com/mycompany/abapci/AdtCommunication/AtcHttpPostHandlerTest.java
+++ b/src/test/java/com/mycompany/abapci/AdtCommunication/AtcHttpPostHandlerTest.java
@@ -38,7 +38,7 @@ public class AtcHttpPostHandlerTest {
     public void SimpleTest() throws IOException {
        
         SapConnectionInfo sapConnectionInfo = null; 
-        AtcHttpPostHandler  cut  = new AtcHttpPostHandler(sapConnectionInfo, "SAP_TEST_PACKAGE", null); 
+        AtcHttpPostHandler  cut  = new AtcHttpPostHandler(sapConnectionInfo, "SAP_TEST_PACKAGE", null, "DEFAULT"); 
         String postMessage = cut.GetPostMessage(); 
         Assert.assertNotNull(postMessage);
         Assert.assertTrue(postMessage.contains("/sap/bc/adt/vit/wb/object_type/devck/object_name/SAP_TEST_PACKAGE"));  

--- a/src/test/java/com/mycompany/resultParser/JsonParserTest.java
+++ b/src/test/java/com/mycompany/resultParser/JsonParserTest.java
@@ -25,7 +25,7 @@ package com.mycompany.resultParser;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
+
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -48,7 +48,7 @@ public class JsonParserTest {
                 + "</aunit:runResult>";
 
         UnittestResultParser jsonParser = new UnittestResultParser();
-        int failedUnittests = jsonParser.parseXmlForFailedElements(testresult);
+        int failedUnittests = jsonParser.parseXmlForFailedElements(testresult).getNumOfFailedTests();
         Assert.assertEquals(0, failedUnittests);
 
     }
@@ -60,7 +60,7 @@ public class JsonParserTest {
         String str = FileUtils.readFileToString(file, "utf-8");
 
         UnittestResultParser jsonParser = new UnittestResultParser();
-        int failedUnittests = jsonParser.parseXmlForFailedElements(str);
+        int failedUnittests = jsonParser.parseXmlForFailedElements(str).getNumOfFailedTests();
         Assert.assertEquals(0, failedUnittests);
 
     }
@@ -71,7 +71,7 @@ public class JsonParserTest {
         File file = new File(classLoader.getResource("sampleAtcResult.xml").getFile());
         String str = FileUtils.readFileToString(file, "utf-8");
 
-        AtcCheckResultParser jsonParser = new AtcCheckResultParser();
+        AtcCheckResultParser jsonParser = new AtcCheckResultParser(true);
         int failedAtcChecks = jsonParser.parseXmlForFailedElements(str);
         Assert.assertEquals(1, failedAtcChecks);
     }
@@ -82,12 +82,10 @@ public class JsonParserTest {
         File file = new File(classLoader.getResource("sampleAtcResultWithAtcToolFailures.xml").getFile());
         String str = FileUtils.readFileToString(file, "utf-8");
 
-        AtcCheckResultParser jsonParser = new AtcCheckResultParser();
+        AtcCheckResultParser jsonParser = new AtcCheckResultParser(true);
         int failedAtcChecks = jsonParser.parseXmlForFailedElements(str);
         Assert.assertEquals(82, failedAtcChecks);
-
     }
-
 
     @Test
     public void SimpleTestUnittestResultNoTests() throws IOException {
@@ -96,19 +94,42 @@ public class JsonParserTest {
         String str = FileUtils.readFileToString(file, "utf-8");
 
         UnittestResultParser jsonParser = new UnittestResultParser();
-        int failedUnittests = jsonParser.parseXmlForFailedElements(str);
+        int failedUnittests = jsonParser.parseXmlForFailedElements(str).getNumOfFailedTests();
         Assert.assertEquals(0, failedUnittests);
     }
 
-        @Test
+    @Test
     public void SimpleTestUnittestResultWithFailure() throws IOException {
         ClassLoader classLoader = getClass().getClassLoader();
         File file = new File(classLoader.getResource("unittestResultWithFailure.xml").getFile());
         String str = FileUtils.readFileToString(file, "utf-8");
 
         UnittestResultParser jsonParser = new UnittestResultParser();
-        int failedUnittests = jsonParser.parseXmlForFailedElements(str);
+        int failedUnittests = jsonParser.parseXmlForFailedElements(str).getNumOfFailedTests();
         Assert.assertEquals(1, failedUnittests);
+    }
+    
+    @Test
+    public void TestUnittestResultForNW752WithFailures() throws IOException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource("unitTestResultForNW752.xml").getFile());
+        String str = FileUtils.readFileToString(file, "utf-8");
+
+        UnittestResultParser jsonParser = new UnittestResultParser();
+        UnitTestResult unitTestResult = jsonParser.parseXmlForFailedElements(str);
+        Assert.assertEquals(2, unitTestResult.getNumOfFailedTests());
+        Assert.assertEquals(9, unitTestResult.getMessages().size());
+    }
+    
+    @Test
+    public void atcResultWithErrorsAndWarningsSkipped() throws IOException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource("sampleAtcResultWithAtcToolFailures.xml").getFile());
+        String str = FileUtils.readFileToString(file, "utf-8");
+
+        AtcCheckResultParser jsonParser = new AtcCheckResultParser(false);
+        int failedAtcChecks = jsonParser.parseXmlForFailedElements(str);
+        Assert.assertEquals(28, failedAtcChecks);
     }
 
 }

--- a/src/test/resources/unitTestResultForNW752.xml
+++ b/src/test/resources/unitTestResultForNW752.xml
@@ -1,0 +1,45 @@
+?xml version="1.0" encoding="utf-8"?>
+<aunit:runResult xmlns:aunit="http://www.sap.com/adt/aunit">
+    <program adtcore:uri="/sap/bc/adt/oo/classes/zcl_demo_d_calc_salesorder_id" adtcore:type="CLAS/OC" adtcore:name="ZCL_DEMO_D_CALC_SALESORDER_ID" uriType="classic"
+        xmlns:adtcore="http://www.sap.com/adt/core">
+        <testClasses>
+            <testClass adtcore:uri="/sap/bc/adt/oo/classes/zcl_demo_d_calc_salesorder_id/includes/testclasses#start=13,6" adtcore:type="CLAS/OCN/testclasses" adtcore:name="LTC1" uriType="classic" durationCategory="short" riskLevel="harmless">
+                <testMethods>
+                    <testMethod adtcore:uri="/sap/bc/adt/oo/classes/zcl_demo_d_calc_salesorder_id/includes/testclasses#start=15,9" adtcore:type="CLAS/OCN/testclasses" adtcore:name="MAKE_ACTION" executionTime="0" uriType="classic" unit="s">
+                        <alerts>
+                            <alert kind="failedAssertion" severity="critical">
+                                <title>Critical Assertion Error: 'Make_Action: ASSERT_SUBRC'</title>
+                                <details>
+                                    <detail text="Return Code sy-subrc [4] (Expected [0])"/>
+                                    <detail text="'SubRc differs.'"/>
+                                    <detail text="Test 'LTC1-&gt;MAKE_ACTION' in Main Program 'ZCL_DEMO_D_CALC_SALESORDER_ID=CP'."/>
+                                </details>
+                                <stack>
+                                    <stackEntry adtcore:uri="/sap/bc/adt/oo/classes/zcl_demo_d_calc_salesorder_id/includes/testclasses#start=16,0" adtcore:type="CLAS/OCN/testclasses" adtcore:name="ZCL_DEMO_D_CALC_SALESORDER_ID" adtcore:description="Include: &lt;ZCL_DEMO_D_CALC_SALESORDER_ID=CCAU&gt; Line: &lt;16&gt; (MAKE_ACTION)"/>
+                                </stack>
+                            </alert>
+                        </alerts>
+                    </testMethod>
+                    <testMethod adtcore:uri="/sap/bc/adt/oo/classes/zcl_demo_d_calc_salesorder_id/includes/testclasses#start=19,9" adtcore:type="CLAS/OCN/testclasses" adtcore:name="SUBMIT_RESULT" executionTime="0" uriType="classic" unit="s">
+                        <alerts>
+                            <alert kind="failedAssertion" severity="critical">
+                                <title>Critical Assertion Error: 'Submit_Result: ASSERT_EQUALS'</title>
+                                <details>
+                                    <detail text="Different Values:">
+                                        <details>
+                                            <detail text="Expected [A] Actual [D]"/>
+                                        </details>
+                                    </detail>
+                                    <detail text="Test 'LTC1-&gt;SUBMIT_RESULT' in Main Program 'ZCL_DEMO_D_CALC_SALESORDER_ID=CP'."/>
+                                </details>
+                                <stack>
+                                    <stackEntry adtcore:uri="/sap/bc/adt/oo/classes/zcl_demo_d_calc_salesorder_id/includes/testclasses#start=20,0" adtcore:type="CLAS/OCN/testclasses" adtcore:name="ZCL_DEMO_D_CALC_SALESORDER_ID" adtcore:description="Include: &lt;ZCL_DEMO_D_CALC_SALESORDER_ID=CCAU&gt; Line: &lt;20&gt; (SUBMIT_RESULT)"/>
+                                </stack>
+                            </alert>
+                        </alerts>
+                    </testMethod>
+                </testMethods>
+            </testClass>
+        </testClasses>
+    </program>
+</aunit:runResult>


### PR DESCRIPTION
- add Accept header for HTTP requests
- adjust unit test parser to match 7.52 result
- introduce UnitTestResult which holds information about number of
failed tests and messages
- adjust logic for receiving results - unit test texts are passed to the
output log
- adjust final message; the final logic now checks whether ATC and/or
unit tests failed
- remove the raw output from the final log
- introduce parameter for ATC check variant (in a job), which is used
for running ATC check
- introduce parameter for choosing whether ATC warnings should be
treated like failures for the job
- adjust unit tests